### PR TITLE
Correct keystore derivation path from Litecoin's 2' to Viacoins 14'

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -685,7 +685,7 @@ is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 
 
 def bip44_derivation(account_id, bip43_purpose=44):
-    coin = 1 if bitcoin.NetworkConstants.TESTNET else 2
+    coin = 13 if bitcoin.NetworkConstants.TESTNET else 14
     return "m/%d'/%d'/%d'" % (bip43_purpose, coin, int(account_id))
 
 def from_seed(seed, passphrase, is_p2sh):


### PR DESCRIPTION
Also sets the testnet key derivation path to 13'. Is this the correct testnet derivation path? Please test this on a wallet containing coins before merging. Tested it for both Ledger Nano S and Digital Bitbox. Once merged, this should resolve #10 